### PR TITLE
Bump @azure/msal-node

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -301,17 +301,24 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.8.1.tgz",
-      "integrity": "sha512-VcZZM+5VvCWRBTOF7SxMKaxrz+EXjntx2u5AQe7QE06e6FuPJElGBrImgNgCh5QmFaNCfVFO+3qNR7UoFD/Gfw==",
-      "license": "MIT",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.9.2.tgz",
+      "integrity": "sha512-8tvi6Cos3m+0KmRbPjgkySXi+UQU/QiuVRFnrxIwt5xZlEEFa69O04RTaNESGgImyBBlYbo2mfE8/U8Bbdk1WQ==",
       "dependencies": {
-        "@azure/msal-common": "14.10.0",
+        "@azure/msal-common": "14.12.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "14.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.12.0.tgz",
+      "integrity": "sha512-IDDXmzfdwmDkv4SSmMEyAniJf6fDu3FJ7ncOjlxkDuT85uSnLEhZi3fGZpoR7T4XZpOMx9teM9GXBgrfJgyeBw==",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@hapi/hoek": {


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the /backend directory: [@azure/msal-node](https://github.com/AzureAD/microsoft-authentication-library-for-js).


Updates `@azure/msal-node` from 2.8.1 to 2.9.2
- [Release notes](https://github.com/AzureAD/microsoft-authentication-library-for-js/releases)
- [Commits](https://github.com/AzureAD/microsoft-authentication-library-for-js/commits/msal-node-v2.9.2)

---
updated-dependencies:
- dependency-name: "@azure/msal-node" dependency-type: indirect dependency-group: npm_and_yarn ...